### PR TITLE
Add IConverterUsage to FoundRegion

### DIFF
--- a/Commands/Converters/FoundRegion.cs
+++ b/Commands/Converters/FoundRegion.cs
@@ -7,8 +7,10 @@ namespace KindredArenass.Commands.Converters;
 
 
 public record struct FoundRegion(WorldRegionType Value, string Name);
-public class FoundRegionConverter : CommandArgumentConverter<FoundRegion>
+public class FoundRegionConverter : CommandArgumentConverter<FoundRegion>, IConverterUsage
 {
+	public string Usage => "start, woods, farmlands, forest, mountains, hills, south, north, ruins, none";
+
 	public override FoundRegion Parse(ICommandContext ctx, string input)
 	{
 		var region = Enum.GetValues(typeof(WorldRegionType)).Cast<WorldRegionType>().FirstOrDefault(x => x.ToString().Equals(input, StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
This adds usage information to `FoundRegion` commands help as a simple list of the regions.

![image](https://github.com/Odjit/KindredArenas/assets/62450933/7f4b9e2b-e4c4-40c7-8ada-7ce9cf67cb4e)